### PR TITLE
Add auto darkmode

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -20,6 +20,8 @@ plugins:
 # Theme-specific settings
 
 minima:
+  skin: auto
+
   # Minima date format.
   # Refer to https://shopify.github.io/liquid/filters/date/ if you want to customize this.
   #

--- a/_sass/minima/custom-styles.scss
+++ b/_sass/minima/custom-styles.scss
@@ -1,0 +1,3 @@
+img {
+    background-color: $lm-background-color;
+}


### PR DESCRIPTION
Uses the new Minima feature `skin` to automatically show the blog in dark mode if the user's system has it enabled.

Sets the background colour of all images to the light mode background colour so that images with transparency look good in dark mode:
![image](https://github.com/user-attachments/assets/a73f1ea8-7a4e-4e48-b436-39b47cf00069)
