### PR TITLE
Bump `uri` gem version to resolve vulnerability

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -288,7 +288,7 @@ GEM
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (1.8.0)
-    uri (1.0.2)
+    uri (1.0.3)
     webrick (1.9.1)
 
 PLATFORMS
@@ -297,6 +297,7 @@ PLATFORMS
   arm-linux-gnu
   arm-linux-musl
   arm64-darwin
+  arm64-darwin-24
   x86_64-darwin
   x86_64-linux-gnu
   x86_64-linux-musl


### PR DESCRIPTION
Resolves https://github.com/vllm-project/vllm-project.github.io/security/dependabot/9