### PR TITLE
Fixed documentation error in CUDA Coredump Blog

### DIFF
--- a/_posts/2025-08-11-cuda-debugging.md
+++ b/_posts/2025-08-11-cuda-debugging.md
@@ -96,14 +96,13 @@ __global__ void illegalMemoryAccessKernel(int* data, int size) {
     }
 }
 
-// Kernel with illegal memory access - accesses memory beyond allocated bounds
+// Normal kernel which does not generate an illegal memory access
 __global__ void normalKernel(int* data, int size) {
     int idx = blockIdx.x * blockDim.x + threadIdx.x;
     
-    // This will cause illegal memory access - accessing beyond allocated memory
-    // We allocate 'size' elements but access up to size * 2
-    if (idx < size) {  // Access twice the allocated size
-        data[idx] = idx;   // 
+   
+    if (idx < size) { 
+        data[idx] = idx;   
     }
 }
 


### PR DESCRIPTION
In the CUDA Coredump blog, an incorrect documentation statement is made for this kernel:

// Kernel with illegal memory access - accesses memory beyond allocated bounds
__global__ void normalKernel(int* data, int size) {
    int idx = blockIdx.x * blockDim.x + threadIdx.x;
    
    // This will cause illegal memory access - accessing beyond allocated memory
    // We allocate 'size' elements but access up to size * 2
    if (idx < size) {  // Access twice the allocated size
        data[idx] = idx;   // 
    }
} 

To my knowledge, this should not generate an illegal memory access, as the size allocated is fine in the source code as well. There is also an incomplete comment for data[idx] = idx; so I'm making the assumption that these comments are a mistake