### PR TITLE
Update copyright year to 2026

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,6 @@
 title: vLLM Blog
 author:
-  name: © 2025. vLLM Team. All rights reserved.
+  name: © 2026. vLLM Team. All rights reserved.
 google_analytics: G-9C5R3JR3QS
 url: https://blog.vllm.ai
 logo: /assets/logos/vllm-logo-only-light.png


### PR DESCRIPTION
Update copyright year to 2026 for the blog.