### PR TITLE
docs: fix IsoExec typos and math formatting

### DIFF
--- a/_posts/2026-08-21-isoexec.md
+++ b/_posts/2026-08-21-isoexec.md
@@ -113,7 +113,7 @@ Additionally, IsoExec applies the same principle to EP and SP. For expert parall
 
 Eliminating mismatch is more complex for linear-attention architectures because training and inference use different algorithms. Existing GDN systems use a chunkwise-parallel form for training and prefill but a recurrent form for decode. Although mathematically identical, the algorithms have different floating-point rounding characteristics. Comparing GDN layer outputs from [FLA's](https://github.com/fla-org/flash-linear-attention) chunkwise-parallel kernel with vLLM's fused recurrent kernel, we observed a mean per-element absolute difference of approximately $1.7 \times 10^{-2}$ and a maximum difference of 0.25.
 
-[Tthe TorchTitan team](https://yichuan-w.github.io/blog/GDN-train-inference-mismatch-asyncRL/) addressed this issue by using the recurrent form for both rollout prefill and the trainer's forward pass, and the chunkwise form only for backward computation. Although this removes mismatch for GDN, it makes rollout prefill and the trainer's forward pass serial in the sequence length. They report a slowdown of roughly 2–3× on math workloads and about 5× on a terminal-agent workload, making the approach impractical for full training jobs.
+[The TorchTitan team](https://yichuan-w.github.io/blog/GDN-train-inference-mismatch-asyncRL/) addressed this issue by using the recurrent form for both rollout prefill and the trainer's forward pass, and the chunkwise form only for backward computation. Although this removes mismatch for GDN, it makes rollout prefill and the trainer's forward pass serial in the sequence length. They report a slowdown of roughly 2–3× on math workloads and about 5× on a terminal-agent workload, making the approach impractical for full training jobs.
 
 To ensure zero contract-covered mismatch while achieving high throughput for prefill, training, and decode, we designed **chunkwise-parallel recurrent (CPR)**. CPR keeps the recurrence as the main function but evaluates it in parallel across chunks. For training and prefill, as in the chunkwise-parallel form, a first pass computes the recurrent state at every chunk boundary; a parallel recurrent scan then computes the outputs within each chunk. For decode, we use the recurrent form but resynchronize the hidden state every $C$ decoded tokens, where $C$ is the chunk size. This ensures a consistent rounding schedule across prefill, training, and decode.
 
@@ -136,7 +136,7 @@ For our experiments, we compared IsoExec against SkyRL's native stack on a singl
 
 ![Rollout-versus-training absolute logprob differences for the native SkyRL stack and IsoExec.](/assets/figures/2026-08-21-isoexec/result_logprob_diff.png)
 
-Across 50 steps, the mean pre-update rollout-versus-training absolute logprob difference reduced from $1.648 \times 10^{-2}$ to $6.744 \times 10^{-7}$, its standard deviation reduced from $4.035 \times 10^{-2}$ to $6.821 \times 10^{-7}$, and the average per-step maximum reduced from 5.073 to $7.358 \times 10^{-6}$.
+Across 50 steps, the mean pre-update rollout-versus-training absolute logprob difference reduced from $1.648 \times 10^{-2}$ to $6.744 \times 10^{-7}$, its standard deviation reduced from $4.035 \times 10^{-2}$ to $6.821 \times 10^{-7}$, and the average per-step maximum reduced from $5.073$ to $7.358 \times 10^{-6}$.
 
 <p class="result-figure-label">Performance</p>
 


### PR DESCRIPTION
## Motivation

Fix typos and math formatting for readability.