### PR TITLE
Fix GLM 5.3 calculator width

### DIFF
--- a/_posts/2026-09-07-glm53-part1-hybrid-sparse-offloading.md
+++ b/_posts/2026-09-07-glm53-part1-hybrid-sparse-offloading.md
@@ -91,7 +91,7 @@ The calculator shows the minimum HiSparse host pool required to keep CPU memory 
   src="/assets/interactive_pages/hisparse_concurrency_calculator.html"
   title="Hybrid sparse offloading concurrency calculator"
   loading="lazy"
-  width="100%"
+  width="768"
   height="1520"
   scrolling="no"
   style="border: 0; border-radius: 12px;"


### PR DESCRIPTION
## Summary

- use the blog article width (768 px) as the calculator iframe’s numeric width
- avoid the live renderer interpreting `width="100%"` as 100 px

## Testing

- `git diff --check`
- `bundle exec jekyll build` *(not run: local Jekyll executable is not installed)*